### PR TITLE
Updated database account name in template

### DIFF
--- a/ArmTemplates/logic-apps.json
+++ b/ArmTemplates/logic-apps.json
@@ -243,7 +243,7 @@
                 "displayName": "CosmosDBConnection",
                 "customParameterValues": {},
                 "parameterValues": {
-                    "databaseAccount": "[parameters('cosmosDbAccountName')]",
+                    "databaseAccount": "[concat('cos-', parameters('cosmosDbAccountName'))]",
                     "accessKey": "[parameters('cosmosDbPrimaryMasterKey')]"
                 },
                 "api": {


### PR DESCRIPTION
Fix for #14 to initialize API Connection with the appropriate database account name.